### PR TITLE
add missing instruction to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,11 @@ dhtcrawler is a DHT crawler written in erlang. It can join a DHT network and cra
 * compile 
 
         rebar compile
-        
+
+* starting the erlang shell with the ebin path added
+
+        erl -pa ebin
+
 * start dhtcrawler
 
         crawler_app:start()


### PR DESCRIPTION
I find the instructions on the README.md  is different from your blog page,so i add the missing part back.

sorry for my poor english.

=)
